### PR TITLE
 </user_name>の変換ミスとapi制限に引っかかってたの修正

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -15,7 +15,9 @@ def get_new_mention_timeline(client, prev_check_time)
   client.mentions_timeline.select{|t| t.created_at > prev_check_time}
 end
 
-interval = 3
+# 15分に75回までの制約あり。余裕を持って+1秒してる
+# https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-mentions_timeline.html
+interval = (60 * 15 / 75) + 1
 prev_check_time = Time.now.getutc - interval
 yuzu = Yuzu.new
 

--- a/yuzu.rb
+++ b/yuzu.rb
@@ -17,7 +17,7 @@ class Yuzu
   end
 
   def replace_command(message, tweet)
-    message.gsub("</user_name>", "tweet.user.name")
+    message.gsub("</user_name>", tweet.user.name)
   end
 
   def reply_message(tweet)


### PR DESCRIPTION
■api制限
日本語訳間違っていた(15回15秒)
http://westplain.sakuraweb.com/translate/twitter/Documentation/REST-APIs/Public-API/GET-statuses-mentions_timeline.cgi

原文は
Requests / 15-min window (user auth)    75
15分に75回っぽい
https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-mentions_timeline.html