### PR TITLE
bot起動/停止時に表示名とテーマカラーを変更する

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -29,7 +29,11 @@ last_logout_time = get_last_logout_time(client, yuzu).getutc
 login_message = yuzu.login_message
 client.update(login_message)
 p login_message
-client.update_profile({location: yuzu.login_status_message})
+client.update_profile({
+  name: yuzu.user_name_actived,
+  location: yuzu.login_status_message,
+  profile_link_color: yuzu.user_profile_link_color_actived
+})
 
 interval = (60 * 15 / 75) + 1
 prev_check_time = last_logout_time
@@ -55,5 +59,9 @@ ensure
   logout_message = yuzu.logout_message
   client.update(logout_message)
   p logout_message
-  client.update_profile({location: yuzu.logout_status_message})
+  client.update_profile({
+    name: yuzu.user_name_sleeped,
+    location: yuzu.logout_status_message,
+    profile_link_color: yuzu.user_profile_link_color_sleeped
+  })
 end

--- a/yuzu.rb
+++ b/yuzu.rb
@@ -21,8 +21,24 @@ class Yuzu
     Time.now.to_s.gsub(" +0900", "")
   end
 
-  def user_name
+  def user_screen_name
     "yuzu_amechan"
+  end
+
+  def user_name_actived
+    "yuzu🍬"
+  end
+
+  def user_name_sleeped
+    "yuzu💤🍬"
+  end
+
+  def user_profile_link_color_actived
+    "#fdc823"
+  end
+
+  def user_profile_link_color_sleeped
+    "#f1c8d0"
   end
 
   def user_profile(client)
@@ -54,7 +70,7 @@ class Yuzu
   end
 
   def reply_message(tweet)
-    received_message = tweet.text.gsub("@#{user_name}","").strip
+    received_message = tweet.text.gsub("@#{user_screen_name}","").strip
     base_message = reply_message_from_received_message(received_message)
     formatted_message = replace_command(base_message, tweet)
     "@#{tweet.user.screen_name} #{formatted_message}"


### PR DESCRIPTION
今までよりも変化がわかりやすくなった。(アイコン変える手もありそう）
https://syncer.jp/Web/API/Twitter/REST_API/POST/account/update_profile/
このあたり参考にした

起動中
<img width="906" alt="2018-10-12 1 00 25" src="https://user-images.githubusercontent.com/2544432/46817868-d8389c80-cdba-11e8-994b-9098c50fd521.png">

停止中
<img width="927" alt="2018-10-12 1 00 09" src="https://user-images.githubusercontent.com/2544432/46817877-dd95e700-cdba-11e8-9454-3f7290d01a06.png">
