### PR TITLE
意図しない起動/終了のタイミングでつぶやかないようにした

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-bot: ruby app.rb
+bot: bundle exec ruby app.rb

--- a/yuzu.rb
+++ b/yuzu.rb
@@ -39,6 +39,14 @@ class Yuzu
     }
   end
 
+  def set_maintenance_status
+    @maintenance = true
+  end
+
+  def maintenance_mark
+    "💓"
+  end
+
   def user_profile(client)
     "@#{client.user.screen_name}こと#{client.user.name}登場! #{client.user.description} さっきまでは、#{client.user.location}"
   end
@@ -60,7 +68,7 @@ class Yuzu
   end
 
   def logout_status_message
-    "お布団の中#{logout_status_separator}(#{current_jst_time})"
+    "お布団の中#{logout_status_separator}(#{current_jst_time})#{@maintenance ? maintenance_mark : ""}"
   end
 
   def replace_command(message, tweet)


### PR DESCRIPTION
# 概要

この辺のissue対応
https://github.com/ethfumi/yuzu-amechan-bot/issues/24
https://github.com/ethfumi/yuzu-amechan-bot/issues/16

・1日1回Cyclingによって発生
・ローカルで開発時
↑これらを止めたかった。つぶやかなくなったはず。

・herokuから手動で停止した時
↑これは止めたくなかったけど、あわせてつぶやかなくなった。

・デプロイに伴う更新
↑多分止まるようになった。どっちでもよかった。

Cyclingのログ
```
2018-11-01T01:48:41.735851+00:00 heroku[bot.1]: Cycling
2018-11-01T01:48:41.736309+00:00 heroku[bot.1]: State changed from up to starting
2018-11-01T01:48:42.370333+00:00 heroku[bot.1]: Stopping all processes with SIGTERM
2018-11-01T01:48:42.553185+00:00 app[bot.1]: "@fumilin なにかおきたみたいーー #<SignalException: SIGTERM> 2018-11-01 10:48:42"
2018-11-01T01:48:42.750445+00:00 app[bot.1]: "まったね〜。ばいばーい🍭(2018-11-01 10:48:42)"
2018-11-01T01:48:43.072194+00:00 heroku[bot.1]: Process exited with status 0
```

herokuから手動で停止した時のログ(SignalException)が一緒
```
2018-11-01T02:30:21.030661+00:00 heroku[bot.1]: State changed from up to down
2018-11-01T02:30:21.606846+00:00 heroku[bot.1]: Stopping all processes with SIGTERM
2018-11-01T02:30:21.768163+00:00 app[bot.1]: "@fumilin なにかおきたみたいーー #<SignalException: SIGTERM> 2018-11-01 11:30:21"
2018-11-01T02:30:21.948220+00:00 app[bot.1]: "まったね〜。ばいばーい🍭(2018-11-01 11:30:21)"
2018-11-01T02:30:22.195878+00:00 heroku[bot.1]: Process exited with status 0
```